### PR TITLE
Improve logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>edu.ucla.library</groupId>
   <artifactId>kakadu-lambda-converter</artifactId>
   <version>0.0.1-SNAPSHOT</version>
@@ -45,23 +46,19 @@
     <force.destroy.jp2.bucket>false</force.destroy.jp2.bucket>
     <kakadu.lib.layer.versioned.arn>SUPPLY-YOUR-OWN</kakadu.lib.layer.versioned.arn>
     <kakadu.bin.layer.versioned.arn>SUPPLY-YOUR-OWN</kakadu.bin.layer.versioned.arn>
-
     <!-- Versions of project dependencies -->
-    <freelib.utils.version>0.8.9</freelib.utils.version>
+    <freelib.utils.version>0.8.10</freelib.utils.version>
     <lambda.logging.version>1.0.0</lambda.logging.version>
     <lambda.events.version>2.2.6</lambda.events.version>
     <lambda.core.version>1.2.0</lambda.core.version>
     <aws.sdk.version>1.11.534</aws.sdk.version>
     <jackson.version>2.9.8</jackson.version>
-
     <!-- Versions of test dependencies -->
     <mockito.version>2.27.0</mockito.version>
-
     <!-- Versions of plug-ins -->
     <aws.plugin.version>0.2.18</aws.plugin.version>
     <shade.plugin.version>3.0.0</shade.plugin.version>
     <codacy.plugin.version>1.0.2</codacy.plugin.version>
-
     <!-- Build configuration properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -86,6 +83,7 @@
       <groupId>io.symphonia</groupId>
       <artifactId>lambda-logging</artifactId>
       <version>${lambda.logging.version}</version>
+      <classifier>no-config</classifier>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -112,7 +110,6 @@
       <artifactId>aws-java-sdk-lambda</artifactId>
       <version>${aws.sdk.version}</version>
     </dependency>
-
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -250,7 +247,8 @@
         <configuration>
           <environmentVariables>
             <DESTINATION_BUCKET>${jp2.s3.bucket}</DESTINATION_BUCKET>
-            <AWS_REGION>us-east-1</AWS_REGION>
+            <AWS_REGION>${lambda.region}</AWS_REGION>
+            <CI>true</CI>
           </environmentVariables>
           <argLine>${jacoco.agent.arg}</argLine>
         </configuration>
@@ -269,7 +267,7 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4</version>
   </parent>
 
 </project>

--- a/src/main/generated/edu/ucla/library/lambda/kakadu/converter/MessageCodes.java
+++ b/src/main/generated/edu/ucla/library/lambda/kakadu/converter/MessageCodes.java
@@ -9,6 +9,10 @@ final public class MessageCodes {
 	 */
 	public static final String LKC_006 = "LKC-006";
 	/**
+	 * Message: Kakadu output: {}
+	 */
+	public static final String LKC_112 = "LKC-112";
+	/**
 	 * Message: Byte array is {} bytes long
 	 */
 	public static final String LKC_005 = "LKC-005";

--- a/src/main/java/edu/ucla/library/lambda/kakadu/converter/Constants.java
+++ b/src/main/java/edu/ucla/library/lambda/kakadu/converter/Constants.java
@@ -9,10 +9,13 @@ package edu.ucla.library.lambda.kakadu.converter;
  */
 public final class Constants {
 
+    /** The source file for our messages resource bundle */
     public static final String MESSAGES = "kakadu-lambda-converter_messages";
 
+    /** The image ID */
     public static final String ID = "id";
 
+    /** The name of the environmental variable for the destination bucket */
     public static final String DESTINATION_BUCKET = "DESTINATION_BUCKET";
 
     private Constants() {

--- a/src/main/resources/kakadu-lambda-converter_messages.xml
+++ b/src/main/resources/kakadu-lambda-converter_messages.xml
@@ -18,4 +18,5 @@
   <entry key="LKC-009">Conversion process returned an empty JP2: {}</entry>
   <entry key="LKC-010">S3 object '{}' could not be written to the file system: {}</entry>
   <entry key="LKC-111">Error converting image to JP2: {}</entry>
+  <entry key="LKC-112">Kakadu output: {}</entry>
 </properties>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,13 +1,15 @@
 <configuration>
 
-  <appender name="STDOUT" class="io.symphonia.lambda.logging.DefaultConsoleAppender">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %X{AWSRequestId:-"NO_REQUEST_ID"} [%level] %logger{36}:%X{line} - %msg</pattern>
+      <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
     </encoder>
   </appender>
 
+  <!-- Our own loggers -->
+  <logger name="info.freelibrary.util" level="WARN"/>
+
   <!-- We're going to be explicit about what we don't want to see -->
-  <logger name="info.freelibrary.util" level="WARN" />
   <logger name="org.apache.http.wire" level="WARN" />
   <logger name="org.apache.http.headers" level="WARN" />
   <logger name="org.apache.http.impl" level="WARN" />
@@ -23,7 +25,7 @@
   <logger name="com.amazonaws.monitoring.CsmConfigurationProviderChain" level="WARN" />
 
   <root level="DEBUG">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDOUT"/>
   </root>
 
 </configuration>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -63,7 +63,7 @@ resource "aws_lambda_permission" "allow_bucket" {
   source_arn    = "${aws_s3_bucket.source_bucket.arn}"
 }
 
-# Create CloudWatch log group
+# Create CloudWatch log group using the name Lambda expects
 resource "aws_cloudwatch_log_group" "kakadu-converter-log-group" {
   name              = "/aws/lambda/${aws_lambda_function.kakadu_converter.function_name}"
   retention_in_days = 14


### PR DESCRIPTION
Improving our logging makes it easier to parse out useful information from our logs using Amazon Cloudwatch Insights. This PR pulls in an upstream (freelibrary) fix to the logger than allows for line numbers in the log output and for changing the type of EOLs used in the logs. This is useful because Lambda's logging to Cloudwatch creates a new log line on "\n", which is problematic when outputting pretty printed JSON or Kakadu STDOUT information.

In addition to the upstream logger fixes, it changes some of the configuration of the logging in this project and splits logging configs so there is a different test logging config (for Travis and local development) and production logging config (for Lambda/Cloudwatch with its special EOL needs).