### PR TITLE
[IIIF-390] Fix URL encodings and AWS metadata names

### DIFF
--- a/src/main/java/edu/ucla/library/lambda/kakadu/converter/Constants.java
+++ b/src/main/java/edu/ucla/library/lambda/kakadu/converter/Constants.java
@@ -13,10 +13,10 @@ public final class Constants {
     public static final String MESSAGES = "kakadu-lambda-converter_messages";
 
     /** The image ID */
-    public static final String ID = "id";
+    public static final String ID = "image-id";
 
     /** The conversion job name */
-    public static final String JOB_NAME = "jobName";
+    public static final String JOB_NAME = "job-name";
 
     /** The name of the environmental variable for the destination bucket */
     public static final String DESTINATION_BUCKET = "DESTINATION_BUCKET";

--- a/src/main/java/edu/ucla/library/lambda/kakadu/converter/Kakadu.java
+++ b/src/main/java/edu/ucla/library/lambda/kakadu/converter/Kakadu.java
@@ -62,7 +62,8 @@ public class Kakadu {
      */
     public File convert(final String aID, final File aTIFF, final Conversion aConversion) throws IOException,
             InterruptedException {
-        final File jp2 = new File(TMP_DIR, URLEncoder.encode(aID, StandardCharsets.UTF_8.toString()) + JP2_EXT);
+        final String id = aID.contains("/") ? URLEncoder.encode(aID, StandardCharsets.UTF_8.toString()) : aID;
+        final File jp2 = new File(TMP_DIR, id + JP2_EXT);
         final List<String> command = new ArrayList<>();
         final String conversion = aConversion.name();
 

--- a/src/main/java/edu/ucla/library/lambda/kakadu/converter/KakaduConverter.java
+++ b/src/main/java/edu/ucla/library/lambda/kakadu/converter/KakaduConverter.java
@@ -97,7 +97,7 @@ public class KakaduConverter implements RequestHandler<S3Event, Boolean> {
         }
 
         final String bucket = aEvent.getRecords().get(0).getS3().getBucket().getName();
-        final String key = aEvent.getRecords().get(0).getS3().getObject().getKey();
+        final String key = aEvent.getRecords().get(0).getS3().getObject().getUrlDecodedKey();
         final S3Object s3Object = myS3Client.getObject(new GetObjectRequest(bucket, key));
         final ObjectMetadata s3Metadata = s3Object.getObjectMetadata();
         final Optional<String> jobName = Optional.ofNullable(s3Metadata.getUserMetaDataOf(Constants.JOB_NAME));

--- a/src/main/java/edu/ucla/library/lambda/kakadu/converter/StatusUpdate.java
+++ b/src/main/java/edu/ucla/library/lambda/kakadu/converter/StatusUpdate.java
@@ -1,6 +1,7 @@
 
 package edu.ucla.library.lambda.kakadu.converter;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import info.freelibrary.util.StringUtils;
@@ -35,7 +36,7 @@ public class StatusUpdate {
      * @param aImageId The image ID whose status is being updated
      */
     public StatusUpdate(final Optional<String> aJobName, final String aImageId) {
-        this(Optional.empty(), aImageId, false);
+        this(aJobName, aImageId, false);
     }
 
     /**
@@ -70,6 +71,7 @@ public class StatusUpdate {
      * @return The status update
      */
     public StatusUpdate setJobName(final String aJobName) {
+        Objects.requireNonNull(aJobName);
         myJobName = aJobName;
         return this;
     }


### PR DESCRIPTION
* Update ID and job name variables to match recent changes in Bucketeer
* Avoid double encoding IDs that are already URL encoded
* Pull the URL decoded version of the S3 key for downloading it
* Fix stupid copy and paste error breaking the setting of the job name